### PR TITLE
Add comprehensive unit tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterator, List, Tuple
+
+import numpy as np
+
+from nest_super_sampler.pipeline import SuperSamplingPipeline
+
+
+@dataclass
+class FakeReader:
+    frames_data: List[Tuple[int, float, np.ndarray]]
+
+    def info(self) -> Dict[str, float]:
+        return {"fps": 30.0}
+
+    def frames(self) -> Iterator[Tuple[int, float, np.ndarray]]:
+        for item in self.frames_data:
+            yield item
+
+
+class KeepEvenSampler:
+    def should_keep(self, idx: int, ts_sec: float, frame_bgr: np.ndarray) -> bool:
+        return idx % 2 == 0
+
+
+class MultiplySupersampler:
+    def upscale(self, img_bgr: np.ndarray) -> np.ndarray:
+        return img_bgr * 2
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.records: List[Tuple[int, float, np.ndarray, np.ndarray, Dict[str, float]]] = []
+        self.closed = False
+
+    def write(
+        self,
+        frame_idx: int,
+        ts_sec: float,
+        original_bgr: np.ndarray,
+        upscaled_bgr: np.ndarray,
+        metadata: Dict[str, float],
+    ) -> None:
+        self.records.append((frame_idx, ts_sec, original_bgr, upscaled_bgr, metadata))
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class AddOnePreprocessor:
+    def process(self, frame_bgr: np.ndarray) -> np.ndarray:
+        return frame_bgr + 1
+
+
+def test_pipeline_processes_and_records_frames() -> None:
+    frames = [
+        (0, 0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+        (1, 0.1, np.ones((2, 2, 3), dtype=np.uint8)),
+        (2, 0.2, np.full((2, 2, 3), 2, dtype=np.uint8)),
+    ]
+    reader = FakeReader(frames)
+    sampler = KeepEvenSampler()
+    supersampler = MultiplySupersampler()
+    sink = RecordingSink()
+    pipeline = SuperSamplingPipeline(
+        reader,
+        sampler,
+        supersampler,
+        sink,
+        max_frames=None,
+        preprocessor=AddOnePreprocessor(),
+    )
+    metrics = pipeline.run()
+    assert len(sink.records) == 2
+    assert sink.closed
+    first_record = sink.records[0]
+    assert first_record[0] == 0
+    np.testing.assert_array_equal(first_record[3], (frames[0][2] + 1) * 2)
+    assert metrics["frames_read"] == len(frames)
+    assert metrics["frames_kept"] == 2
+    assert metrics["fps_input"] == 30.0
+
+
+def test_pipeline_respects_max_frames() -> None:
+    frames = [
+        (0, 0.0, np.zeros((2, 2, 3), dtype=np.uint8)),
+        (2, 0.2, np.full((2, 2, 3), 2, dtype=np.uint8)),
+        (4, 0.4, np.full((2, 2, 3), 4, dtype=np.uint8)),
+    ]
+    reader = FakeReader(frames)
+    sampler = KeepEvenSampler()
+    supersampler = MultiplySupersampler()
+    sink = RecordingSink()
+    pipeline = SuperSamplingPipeline(
+        reader,
+        sampler,
+        supersampler,
+        sink,
+        max_frames=1,
+        preprocessor=None,
+    )
+    metrics = pipeline.run()
+    assert len(sink.records) == 1
+    assert metrics["frames_kept"] == 1

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -1,0 +1,91 @@
+import cv2
+import numpy as np
+
+from nest_super_sampler.preprocessors import (
+    Deblurrer,
+    Denoiser,
+    FrameProcessingPipeline,
+    GlareReducer,
+    build_preprocessor,
+)
+
+
+def _make_bright_image() -> np.ndarray:
+    img = np.zeros((10, 10, 3), dtype=np.uint8)
+    img[:, :] = [10, 10, 250]
+    return img
+
+
+def test_glare_reducer_lowers_highlights() -> None:
+    reducer = GlareReducer(v_thresh=0.5, s_thresh=1.0, knee_tau=0.2, knee_strength=10.0, dilate_px=0)
+    src = _make_bright_image()
+    result = reducer.process(src)
+    assert result.dtype == np.uint8
+    assert result[..., 2].mean() < src[..., 2].mean()
+
+
+def test_denoiser_runs_without_error() -> None:
+    denoiser = Denoiser(h_luma=3, h_chroma=3, template=3, search=7)
+    noisy = np.random.randint(0, 255, size=(12, 12, 3), dtype=np.uint8)
+    result = denoiser.process(noisy)
+    assert result.shape == noisy.shape
+
+
+def test_deblurrer_increases_contrast() -> None:
+    deblurrer = Deblurrer(alpha=0.8, sigma=0.5)
+    frame = np.tile(np.linspace(0, 255, 20, dtype=np.uint8), (20, 1))
+    frame = cv2.merge([frame, frame, frame])
+    sharpened = deblurrer.process(frame)
+    assert sharpened.dtype == np.uint8
+    assert sharpened.var() >= frame.var()
+
+
+def test_frame_processing_pipeline_chains_processors() -> None:
+    class AddOneProcessor:
+        def process(self, frame_bgr: np.ndarray) -> np.ndarray:
+            return frame_bgr + 1
+
+    pipeline = FrameProcessingPipeline([AddOneProcessor(), AddOneProcessor()])
+    frame = np.zeros((2, 2, 3), dtype=np.uint8)
+    result = pipeline.process(frame)
+    assert np.array_equal(result, frame + 2)
+
+
+def test_build_preprocessor_returns_none_when_disabled() -> None:
+    pre = build_preprocessor(
+        enable_glare=False,
+        enable_denoise=False,
+        enable_deblur=False,
+        glare_v_thresh=0.9,
+        glare_s_thresh=0.4,
+        glare_knee_tau=0.75,
+        glare_knee_strength=3.0,
+        glare_dilate_px=2,
+        denoise_h_luma=7,
+        denoise_h_chroma=5,
+        denoise_template=7,
+        denoise_search=21,
+        deblur_alpha=0.6,
+        deblur_sigma=1.2,
+    )
+    assert pre is None
+
+
+def test_build_preprocessor_returns_pipeline_when_enabled() -> None:
+    pre = build_preprocessor(
+        enable_glare=True,
+        enable_denoise=True,
+        enable_deblur=True,
+        glare_v_thresh=0.9,
+        glare_s_thresh=0.4,
+        glare_knee_tau=0.75,
+        glare_knee_strength=3.0,
+        glare_dilate_px=2,
+        denoise_h_luma=7,
+        denoise_h_chroma=5,
+        denoise_template=7,
+        denoise_search=21,
+        deblur_alpha=0.6,
+        deblur_sigma=1.2,
+    )
+    assert isinstance(pre, FrameProcessingPipeline)

--- a/tests/test_samplers.py
+++ b/tests/test_samplers.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+
+from nest_super_sampler.samplers import CompositeSampler, NthFrameSampler, SceneChangeSampler
+
+
+def test_nth_frame_sampler_keeps_every_nth_frame() -> None:
+    sampler = NthFrameSampler(3)
+    assert sampler.should_keep(0, 0.0, np.zeros((1, 1, 3), dtype=np.uint8))
+    assert not sampler.should_keep(1, 0.0, np.zeros((1, 1, 3), dtype=np.uint8))
+    assert sampler.should_keep(3, 0.0, np.zeros((1, 1, 3), dtype=np.uint8))
+
+
+def test_nth_frame_sampler_rejects_invalid_n() -> None:
+    with pytest.raises(ValueError):
+        NthFrameSampler(0)
+
+
+def test_scene_change_sampler_detects_change() -> None:
+    sampler = SceneChangeSampler(hist_threshold=0.05, min_gap_frames=1)
+    frame1 = np.zeros((8, 8, 3), dtype=np.uint8)
+    frame2 = np.zeros((8, 8, 3), dtype=np.uint8)
+    frame2[:, :4] = [255, 0, 0]
+    frame2[:, 4:] = [0, 255, 0]
+    assert sampler.should_keep(0, 0.0, frame1)
+    assert sampler.should_keep(1, 0.0, frame2)
+    assert not sampler.should_keep(2, 0.0, frame2)
+
+
+def test_composite_sampler_requires_samplers() -> None:
+    with pytest.raises(ValueError):
+        CompositeSampler([])
+
+
+def test_composite_sampler_combines_results() -> None:
+    sampler = CompositeSampler([NthFrameSampler(2), NthFrameSampler(3)])
+    frame = np.zeros((1, 1, 3), dtype=np.uint8)
+    assert sampler.should_keep(2, 0.0, frame)
+    assert sampler.should_keep(3, 0.0, frame)
+    assert not sampler.should_keep(5, 0.0, frame)

--- a/tests/test_sinks.py
+++ b/tests/test_sinks.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+from nest_super_sampler.sinks import DiskImageSink
+
+
+def test_disk_image_sink_writes_images_and_metadata(tmp_path, monkeypatch) -> None:
+    writes = []
+
+    def fake_imwrite(path: str, image: np.ndarray, params=None):  # type: ignore[unused-argument]
+        writes.append(Path(path))
+        return True
+
+    monkeypatch.setattr("cv2.imwrite", fake_imwrite)
+    sink = DiskImageSink(tmp_path, image_format="png", write_full_size_only=False)
+    original = np.zeros((2, 2, 3), dtype=np.uint8)
+    upscaled = np.ones((4, 4, 3), dtype=np.uint8)
+    sink.write(1, 0.033, original, upscaled, {"fps": 30.0})
+    sink.close()
+
+    assert len(writes) == 2
+    metadata = pd.read_csv(tmp_path / "frames_metadata.csv")
+    assert metadata.loc[0, "frame_idx"] == 1
+    assert metadata.loc[0, "sr_w"] == 4
+
+
+def test_disk_image_sink_no_close_when_no_rows(tmp_path, monkeypatch) -> None:
+    close_called = False
+
+    def fake_to_csv(self, path, index=False):  # type: ignore[unused-argument]
+        nonlocal close_called
+        close_called = True
+
+    monkeypatch.setattr(pd.DataFrame, "to_csv", fake_to_csv, raising=False)
+    sink = DiskImageSink(tmp_path)
+    sink.close()
+    assert not close_called

--- a/tests/test_supersamplers.py
+++ b/tests/test_supersamplers.py
@@ -1,0 +1,93 @@
+import sys
+from types import ModuleType
+
+import numpy as np
+import pytest
+
+from nest_super_sampler.config import PipelineConfig, SuperResAlgo
+from nest_super_sampler.supersamplers import (
+    BicubicSuperSampler,
+    DNNSuperSampler,
+    build_supersampler,
+)
+
+
+class DummySR:
+    def __init__(self) -> None:
+        self.model = None
+        self.model_path = None
+
+    def setModel(self, model_name: str, scale: int) -> None:  # noqa: N802 - OpenCV naming
+        self.model = (model_name, scale)
+
+    def readModel(self, model_path: str) -> None:  # noqa: N802 - OpenCV naming
+        self.model_path = model_path
+
+    def upsample(self, img: np.ndarray) -> np.ndarray:
+        return img + 1
+
+
+def install_fake_dnn_module(monkeypatch: pytest.MonkeyPatch) -> DummySR:
+    fake_module = ModuleType("cv2.dnn_superres")
+    instance: DummySR = DummySR()
+
+    def factory() -> DummySR:
+        return instance
+
+    fake_module.DnnSuperResImpl_create = factory  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "cv2.dnn_superres", fake_module)
+    return instance
+
+
+def test_bicubic_supersampler_upscale_changes_shape() -> None:
+    sampler = BicubicSuperSampler(scale=2)
+    image = np.zeros((4, 5, 3), dtype=np.uint8)
+    result = sampler.upscale(image)
+    assert result.shape == (8, 10, 3)
+
+
+def test_bicubic_supersampler_invalid_scale() -> None:
+    with pytest.raises(ValueError):
+        BicubicSuperSampler(scale=0)
+
+
+def test_dnnsupersampler_loads_model_and_upscales(tmp_path, monkeypatch) -> None:
+    instance = install_fake_dnn_module(monkeypatch)
+    model_path = tmp_path / "EDSR_x2.pb"
+    model_path.write_bytes(b"fake")
+    sampler = DNNSuperSampler(SuperResAlgo.EDSR, 2, tmp_path)
+    image = np.ones((2, 2, 3), dtype=np.uint8)
+    result = sampler.upscale(image)
+    assert np.array_equal(result, image + 1)
+    assert instance.model == ("edsr", 2)
+    assert instance.model_path == str(model_path.resolve())
+
+
+def test_dnnsupersampler_missing_model(tmp_path, monkeypatch) -> None:
+    install_fake_dnn_module(monkeypatch)
+    with pytest.raises(FileNotFoundError):
+        DNNSuperSampler(SuperResAlgo.EDSR, 2, tmp_path)
+
+
+def test_build_supersampler_returns_bicubic_when_requested(tmp_path) -> None:
+    cfg = PipelineConfig(
+        input_video=tmp_path / "in.mp4",
+        output_dir=tmp_path / "out",
+        algo=SuperResAlgo.BICUBIC,
+        upscale_factor=3,
+    )
+    sampler = build_supersampler(cfg)
+    assert isinstance(sampler, BicubicSuperSampler)
+
+
+def test_build_supersampler_falls_back_when_missing_model(tmp_path) -> None:
+    cfg = PipelineConfig(
+        input_video=tmp_path / "in.mp4",
+        output_dir=tmp_path / "out",
+        algo=SuperResAlgo.EDSR,
+        upscale_factor=2,
+        model_dir=tmp_path,
+        fail_on_missing_superres=False,
+    )
+    sampler = build_supersampler(cfg)
+    assert isinstance(sampler, BicubicSuperSampler)

--- a/tests/test_video_reader.py
+++ b/tests/test_video_reader.py
@@ -1,0 +1,75 @@
+from pathlib import Path
+from typing import List, Tuple
+
+import numpy as np
+import pytest
+
+from nest_super_sampler.video_reader import OpenCVVideoReader
+
+
+class FakeCapture:
+    def __init__(self, frames: List[np.ndarray], *, opened: bool = True) -> None:
+        self.frames = frames
+        self.opened = opened
+        self.index = 0
+        self.released = False
+
+    def isOpened(self) -> bool:  # noqa: N802 - mimics OpenCV API
+        return self.opened
+
+    def get(self, prop_id: int) -> float:  # noqa: N802 - mimics OpenCV API
+        if prop_id == 5:  # cv2.CAP_PROP_FPS
+            return 24.0
+        if prop_id == 7:  # cv2.CAP_PROP_FRAME_COUNT
+            return len(self.frames)
+        if prop_id == 3:  # width
+            return self.frames[0].shape[1]
+        if prop_id == 4:  # height
+            return self.frames[0].shape[0]
+        return 0.0
+
+    def read(self) -> Tuple[bool, np.ndarray]:  # noqa: N802
+        if self.index >= len(self.frames):
+            return False, np.empty((0, 0, 3), dtype=np.uint8)
+        frame = self.frames[self.index]
+        self.index += 1
+        return True, frame
+
+    def release(self) -> None:
+        self.released = True
+
+
+def test_video_reader_info_and_frames(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "video.mp4"
+    path.write_bytes(b"fake")
+    frames = [np.zeros((2, 3, 3), dtype=np.uint8), np.ones((2, 3, 3), dtype=np.uint8)]
+
+    def fake_capture_factory(_):
+        return FakeCapture(frames)
+
+    monkeypatch.setattr("cv2.VideoCapture", fake_capture_factory)
+    reader = OpenCVVideoReader(path)
+    info = reader.info()
+    assert info["fps"] == 24.0
+    assert info["frame_count"] == len(frames)
+    collected = list(reader.frames())
+    assert len(collected) == len(frames)
+    assert collected[0][0] == 0
+    np.testing.assert_array_equal(collected[0][2], frames[0])
+
+
+def test_video_reader_raises_when_capture_fails(tmp_path, monkeypatch) -> None:
+    path = tmp_path / "video.mp4"
+    path.write_bytes(b"fake")
+
+    def fake_capture_factory(_):
+        return FakeCapture([], opened=False)
+
+    monkeypatch.setattr("cv2.VideoCapture", fake_capture_factory)
+    with pytest.raises(RuntimeError):
+        OpenCVVideoReader(path)
+
+
+def test_video_reader_missing_file(tmp_path) -> None:
+    with pytest.raises(FileNotFoundError):
+        OpenCVVideoReader(tmp_path / "missing.mp4")


### PR DESCRIPTION
## Summary
- add unit tests covering supersamplers, samplers, preprocessors, pipeline, sinks, and video reader classes
- ensure test suite configures import path for package resolution

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dc6ddb3ca8832ca79e4a5d66ec4aa3