### PR TITLE
Ensure daytime detail transfer fallbacks are exercised

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,29 @@ python NestSuperSampler.py path/to/input.mp4 --out ./export
 python -m nest_super_sampler path/to/input.mp4 --out ./export
 ```
 
+For daylight footage recorded at the standard Nest camera frame rate (30 FPS), pass the
+lighting and FPS hints to activate motion blur compensation:
+
+```bash
+python -m nest_super_sampler path/to/daytime.mp4 \
+  --out ./export \
+  --motion-comp \
+  --lighting day \
+  --fps-hint 30
+```
+
+To transfer sharp daytime structure into a noisy night capture, feed either a cached model or
+raw daytime footage:
+
+```bash
+python -m nest_super_sampler path/to/night.mp4 \
+  --out ./export \
+  --lighting night \
+  --motion-comp --fps-hint 15 \
+  --daytime-transfer \
+  --daytime-reference path/to/daytime_reference.mp4
+```
+
 Key arguments:
 
 - `--n`: keep every _n_-th frame (defaults to `15`).
@@ -54,6 +77,8 @@ Key arguments:
 - `--scale`: super-resolution scale factor.
 - `--models`: directory containing `.pb` model files (required for DNN algorithms).
 - `--glare`, `--denoise`, `--deblur`: enable pre-processing stages tuned for night video.
+- `--daytime-transfer`: restore night detail using statistics from daytime media supplied
+  via `--daytime-reference` (video/images) or a cached `.npz` from `--daytime-model`.
 
 Use `python -m nest_super_sampler --help` to see the full list of switches.
 
@@ -62,6 +87,7 @@ Use `python -m nest_super_sampler --help` to see the full list of switches.
 | Scenario | Suggested Flags |
 | --- | --- |
 | Daytime overview recording | `--n 12 --scene --algo bicubic --scale 2 --fmt jpg --jpgq 90`
+| Daytime vehicle tracking (motion deblur) | `--motion-comp --lighting day --fps-hint 30 --algo edsr --scale 2`
 | Night-time with headlights/glare | `--scene --glare --glare-v 0.9 --glare-s 0.35 --glare-k 2.8 --denoise --dn-hl 10 --dn-hc 7`
 | Vehicle identification (close-up) | `--n 6 --scene --algo edsr --scale 4 --models ./models --orig-too --max 300`
 | Quick triage (fast export) | `--n 20 --algo bicubic --scale 2 --fmt png --max 120`
@@ -76,6 +102,43 @@ The codebase follows SOLID principles. Each component honours a small interface 
 swap implementations (for example, by replacing `OpenCVVideoReader` with an FFmpeg-backed
 reader). The `build_pipeline` helper wires together dependencies from `PipelineConfig` to the
 `SuperSamplingPipeline`, keeping the CLI thin and testable.
+
+Programmatic use of the adaptive blur compensation profile mirrors the CLI switches:
+
+```python
+from pathlib import Path
+
+import cv2
+
+from nest_super_sampler import (
+    LightingCondition,
+    PipelineConfig,
+    derive_capture_profile,
+    fit_daytime_detail_model,
+)
+from nest_super_sampler.builders import build_pipeline
+from nest_super_sampler.detail_models import DaytimeDetailModel
+
+day_model: DaytimeDetailModel = fit_daytime_detail_model(
+    [cv2.imread("reference_day.jpg"), cv2.imread("reference_day_2.jpg")]
+)
+model_path = Path("./cached_daytime_model.npz")
+day_model.save(model_path)
+
+cfg = PipelineConfig(
+    input_video=Path("night.mp4"),
+    output_dir=Path("./export"),
+    enable_motion_compensation=True,
+    lighting=LightingCondition.NIGHT,
+    capture_fps_hint=15.0,
+    enable_daytime_detail_transfer=True,
+    daytime_model_path=model_path,
+)
+profile = derive_capture_profile(cfg, {"fps": 15.0})
+print("Estimated blur strength:", profile.motion_blur_strength())
+pipeline = build_pipeline(cfg)
+stats = pipeline.run()
+```
 
 ## CSV output
 

--- a/nest_super_sampler/__init__.py
+++ b/nest_super_sampler/__init__.py
@@ -1,7 +1,19 @@
 """Nest Super Sampler package."""
 
-from .config import PipelineConfig, SuperResAlgo
+from .config import LightingCondition, PipelineConfig, SuperResAlgo
+from .capture_profiles import CaptureProfile, derive_capture_profile
 from .pipeline import SuperSamplingPipeline
 from .cli import main
+from .detail_models import DaytimeDetailModel, fit_daytime_detail_model
 
-__all__ = ["PipelineConfig", "SuperResAlgo", "SuperSamplingPipeline", "main"]
+__all__ = [
+    "PipelineConfig",
+    "SuperResAlgo",
+    "LightingCondition",
+    "CaptureProfile",
+    "derive_capture_profile",
+    "SuperSamplingPipeline",
+    "DaytimeDetailModel",
+    "fit_daytime_detail_model",
+    "main",
+]

--- a/nest_super_sampler/builders.py
+++ b/nest_super_sampler/builders.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from .config import PipelineConfig
+from .capture_profiles import derive_capture_profile
+from .detail_models import DaytimeDetailModel, fit_daytime_model_from_path
 from .pipeline import SuperSamplingPipeline
 from .postprocessors import build_postprocessor
 from .preprocessors import build_preprocessor
@@ -27,6 +31,17 @@ def build_pipeline(cfg: PipelineConfig) -> SuperSamplingPipeline:
     """Assemble the full :class:`SuperSamplingPipeline`."""
 
     reader = OpenCVVideoReader(cfg.input_video)
+    capture_profile = derive_capture_profile(cfg, reader.info())
+    daytime_model: Optional[DaytimeDetailModel] = None
+    if cfg.enable_daytime_detail_transfer:
+        if cfg.daytime_model_path is not None:
+            daytime_model = DaytimeDetailModel.load(cfg.daytime_model_path)
+        elif cfg.daytime_reference_media is not None:
+            daytime_model = fit_daytime_model_from_path(cfg.daytime_reference_media)
+        else:
+            raise ValueError(
+                "Daytime transfer enabled but no --daytime-model or --daytime-reference provided"
+            )
     sampler = build_sampler(cfg)
     supersampler = build_supersampler(cfg)
     sink = DiskImageSink(
@@ -39,6 +54,8 @@ def build_pipeline(cfg: PipelineConfig) -> SuperSamplingPipeline:
         cfg.enable_glare,
         cfg.enable_denoise,
         cfg.enable_deblur,
+        cfg.enable_motion_compensation,
+        cfg.enable_daytime_detail_transfer,
         glare_v_thresh=cfg.glare_v_thresh,
         glare_s_thresh=cfg.glare_s_thresh,
         glare_knee_tau=cfg.glare_knee_tau,
@@ -50,6 +67,8 @@ def build_pipeline(cfg: PipelineConfig) -> SuperSamplingPipeline:
         denoise_search=cfg.denoise_search,
         deblur_alpha=cfg.deblur_alpha,
         deblur_sigma=cfg.deblur_sigma,
+        motion_profile=capture_profile if cfg.enable_motion_compensation else None,
+        daytime_model=daytime_model,
     )
     postprocessor = build_postprocessor(cfg)
     return SuperSamplingPipeline(

--- a/nest_super_sampler/capture_profiles.py
+++ b/nest_super_sampler/capture_profiles.py
@@ -1,0 +1,45 @@
+"""Capture metadata helpers to drive adaptive processing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .config import LightingCondition, PipelineConfig
+
+
+@dataclass(frozen=True)
+class CaptureProfile:
+    """Encapsulate capture metadata used by adaptive filters."""
+
+    fps: float
+    lighting: LightingCondition
+
+    def motion_blur_strength(self) -> float:
+        """Return a normalized blur strength estimate in the range [0.5, 3.5]."""
+
+        reference_fps = 30.0
+        fps_term = reference_fps / max(self.fps, 1.0)
+        lighting_term = {
+            LightingCondition.DAYTIME: 0.75,
+            LightingCondition.NIGHT: 1.35,
+        }.get(self.lighting, 1.0)
+        strength = fps_term * lighting_term
+        return max(0.5, min(strength, 3.5))
+
+    def detail_gain(self) -> float:
+        """Return a multiplier used to recover edge details."""
+
+        base_gain = 0.8
+        return min(1.6, base_gain + 0.25 * self.motion_blur_strength())
+
+
+def derive_capture_profile(cfg: PipelineConfig, info: Dict[str, float]) -> CaptureProfile:
+    """Create a :class:`CaptureProfile` from CLI configuration and reader info."""
+
+    fps = cfg.capture_fps_hint or info.get("fps", 0.0) or 30.0
+    if cfg.lighting is LightingCondition.AUTO:
+        lighting = LightingCondition.DAYTIME if fps >= 20.0 else LightingCondition.NIGHT
+    else:
+        lighting = cfg.lighting
+    return CaptureProfile(fps=fps, lighting=lighting)

--- a/nest_super_sampler/config.py
+++ b/nest_super_sampler/config.py
@@ -8,6 +8,14 @@ from pathlib import Path
 from typing import Optional
 
 
+class LightingCondition(str, Enum):
+    """Qualitative lighting conditions for the capture."""
+
+    AUTO = "auto"
+    DAYTIME = "day"
+    NIGHT = "night"
+
+
 class SuperResAlgo(str, Enum):
     """Supported super-resolution algorithms."""
 
@@ -32,6 +40,11 @@ class PipelineConfig:
     scene_hist_threshold: float = 0.30
     scene_min_gap_frames: int = 20
 
+    # Capture hints
+    capture_fps_hint: Optional[float] = None
+    lighting: LightingCondition = LightingCondition.AUTO
+    enable_motion_compensation: bool = False
+
     # Super-resolution
     upscale_factor: int = 2
     algo: SuperResAlgo = SuperResAlgo.EDSR
@@ -50,6 +63,9 @@ class PipelineConfig:
     enable_glare: bool = False
     enable_denoise: bool = False
     enable_deblur: bool = False
+    enable_daytime_detail_transfer: bool = False
+    daytime_reference_media: Optional[Path] = None
+    daytime_model_path: Optional[Path] = None
 
     # Glare params
     glare_v_thresh: float = 0.90

--- a/nest_super_sampler/detail_models.py
+++ b/nest_super_sampler/detail_models.py
@@ -1,0 +1,134 @@
+"""Daytime detail transfer models for guiding night restoration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List
+
+import cv2
+import numpy as np
+
+from .video_reader import OpenCVVideoReader
+
+_SUPPORTED_IMAGE_SUFFIXES = {".png", ".jpg", ".jpeg", ".tif", ".tiff", ".bmp"}
+
+
+def _to_gray(frame_bgr: np.ndarray) -> np.ndarray:
+    gray = cv2.cvtColor(frame_bgr, cv2.COLOR_BGR2GRAY)
+    return gray.astype(np.float32)
+
+
+def _mean_gradient(gray: np.ndarray) -> float:
+    grad_x = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
+    grad_y = cv2.Sobel(gray, cv2.CV_32F, 0, 1, ksize=3)
+    magnitude = cv2.magnitude(grad_x, grad_y)
+    return float(np.mean(magnitude))
+
+
+def _mean_laplacian(gray: np.ndarray) -> float:
+    laplacian = cv2.Laplacian(gray, cv2.CV_32F, ksize=3)
+    return float(np.mean(np.abs(laplacian)))
+
+
+def _collect_reference_frames(path: Path, max_frames: int = 180) -> List[np.ndarray]:
+    if not path.exists():
+        raise FileNotFoundError(f"Reference media not found: {path}")
+    if path.is_dir():
+        frames: List[np.ndarray] = []
+        for image_path in sorted(path.iterdir()):
+            if image_path.suffix.lower() not in _SUPPORTED_IMAGE_SUFFIXES:
+                continue
+            frame = cv2.imread(str(image_path))
+            if frame is None:
+                continue
+            frames.append(frame)
+            if len(frames) >= max_frames:
+                break
+        if not frames:
+            raise ValueError(f"No readable images found in {path}")
+        return frames
+    reader = OpenCVVideoReader(path)
+    info = reader.info()
+    total_frames = int(info.get("frame_count", 0) or 0)
+    stride = max(1, total_frames // max_frames) if total_frames else 5
+    collected: List[np.ndarray] = []
+    for idx, _, frame in reader.frames():
+        if idx % stride != 0:
+            continue
+        collected.append(frame)
+        if len(collected) >= max_frames:
+            break
+    if not collected:
+        raise ValueError(f"No frames collected from video {path}")
+    return collected
+
+
+@dataclass(frozen=True)
+class DaytimeDetailModel:
+    """Encapsulate gradient statistics from sharp daytime captures."""
+
+    mean_gradient: float
+    mean_laplacian_abs: float
+    base_alpha: float
+    base_sigma: float
+
+    def estimate_parameters(self, gradient: float, laplacian_abs: float) -> tuple[float, float]:
+        """Return adaptive (alpha, sigma) sharpening parameters."""
+
+        gradient_ratio = self.mean_gradient / max(gradient, 1e-3)
+        laplacian_ratio = self.mean_laplacian_abs / max(laplacian_abs, 1e-3)
+        blend = 0.55 * gradient_ratio + 0.45 * laplacian_ratio
+        gain = float(np.clip(blend, 0.85, 3.0))
+        alpha = float(np.clip(self.base_alpha * gain, 0.35, 2.5))
+        sigma = float(np.clip(self.base_sigma / np.sqrt(gain), 0.45, 1.8))
+        return alpha, sigma
+
+    def save(self, path: Path) -> None:
+        np.savez_compressed(
+            path,
+            mean_gradient=self.mean_gradient,
+            mean_laplacian_abs=self.mean_laplacian_abs,
+            base_alpha=self.base_alpha,
+            base_sigma=self.base_sigma,
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> "DaytimeDetailModel":
+        if not path.exists():
+            raise FileNotFoundError(f"Daytime model not found: {path}")
+        with np.load(path) as data:
+            return cls(
+                mean_gradient=float(data["mean_gradient"]),
+                mean_laplacian_abs=float(data["mean_laplacian_abs"]),
+                base_alpha=float(data["base_alpha"]),
+                base_sigma=float(data["base_sigma"]),
+            )
+
+
+def fit_daytime_detail_model(frames: Iterable[np.ndarray]) -> DaytimeDetailModel:
+    gradients: List[float] = []
+    laplacians: List[float] = []
+    for frame in frames:
+        gradient, laplacian = analyze_frame(frame)
+        gradients.append(gradient)
+        laplacians.append(laplacian)
+    if not gradients:
+        raise ValueError("At least one frame is required to build a daytime detail model")
+    mean_grad = float(np.mean(gradients))
+    mean_lap = float(np.mean(laplacians))
+    base_alpha = float(np.clip(0.45 + 0.0025 * mean_lap, 0.45, 1.8))
+    base_sigma = float(np.clip(1.1 - 0.002 * mean_grad, 0.55, 1.4))
+    return DaytimeDetailModel(mean_grad, mean_lap, base_alpha, base_sigma)
+
+
+def fit_daytime_model_from_path(path: Path, max_frames: int = 180) -> DaytimeDetailModel:
+    frames = _collect_reference_frames(path, max_frames=max_frames)
+    return fit_daytime_detail_model(frames)
+
+
+def analyze_frame(frame_bgr: np.ndarray) -> tuple[float, float]:
+    """Return (gradient_mean, laplacian_abs_mean) metrics for a frame."""
+
+    gray = _to_gray(frame_bgr)
+    return _mean_gradient(gray), _mean_laplacian(gray)

--- a/tests/test_detail_models.py
+++ b/tests/test_detail_models.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from nest_super_sampler.detail_models import (
+    DaytimeDetailModel,
+    _collect_reference_frames,
+    analyze_frame,
+    fit_daytime_detail_model,
+    fit_daytime_model_from_path,
+)
+from nest_super_sampler.capture_profiles import derive_capture_profile
+from nest_super_sampler.config import LightingCondition, PipelineConfig
+from nest_super_sampler.preprocessors import DayNightDetailTransfer
+
+
+def _write_reference_images(root: Path, count: int = 3) -> None:
+    for idx in range(count):
+        image = np.zeros((32, 32, 3), dtype=np.uint8)
+        cv2.line(image, (0, idx + 4), (31, idx + 4), (255, 255, 255), 1)
+        cv2.imwrite(str(root / f"frame_{idx}.png"), image)
+
+
+def _write_reference_video(path: Path, frame_count: int = 12) -> None:
+    fourcc = cv2.VideoWriter_fourcc(*"MJPG")
+    writer = cv2.VideoWriter(str(path), fourcc, 24.0, (32, 32))
+    if not writer.isOpened():  # pragma: no cover - guard in case codec is unavailable
+        raise RuntimeError("Failed to create reference video for testing")
+    for idx in range(frame_count):
+        frame = np.zeros((32, 32, 3), dtype=np.uint8)
+        cv2.rectangle(frame, (4 + idx % 4, 4), (28, 28), (255, 255, 255), 1)
+        writer.write(frame)
+    writer.release()
+
+
+def test_collect_reference_frames_from_directory(tmp_path) -> None:
+    _write_reference_images(tmp_path)
+    frames = _collect_reference_frames(tmp_path, max_frames=2)
+    assert len(frames) == 2
+
+
+def test_collect_reference_frames_from_video(tmp_path) -> None:
+    video_path = tmp_path / "daytime.avi"
+    _write_reference_video(video_path)
+    frames = _collect_reference_frames(video_path, max_frames=5)
+    assert len(frames) == 5
+
+
+def test_fit_daytime_model_from_path_for_directory(tmp_path) -> None:
+    _write_reference_images(tmp_path)
+    model = fit_daytime_model_from_path(tmp_path)
+    assert isinstance(model, DaytimeDetailModel)
+
+
+def test_fit_daytime_model_from_path_for_video(tmp_path) -> None:
+    video_path = tmp_path / "daytime.avi"
+    _write_reference_video(video_path, frame_count=6)
+    model = fit_daytime_model_from_path(video_path, max_frames=4)
+    assert isinstance(model, DaytimeDetailModel)
+
+
+def test_daynight_detail_transfer_falls_back_when_detail_reduces() -> None:
+    reference = np.zeros((32, 32, 3), dtype=np.uint8)
+    cv2.rectangle(reference, (6, 6), (26, 26), (255, 255, 255), 2)
+    model = fit_daytime_detail_model([reference])
+    transfer = DayNightDetailTransfer(model, residual_blend=-0.5)
+    night_frame = cv2.GaussianBlur(reference, (0, 0), 1.2)
+
+    result = transfer.process(night_frame)
+    gradient, laplacian = analyze_frame(night_frame)
+    alpha, sigma = model.estimate_parameters(gradient, laplacian)
+    softened = cv2.GaussianBlur(night_frame, (0, 0), sigma)
+    unsharp = cv2.addWeighted(night_frame, 1 + alpha, softened, -alpha, 0)
+
+    assert np.array_equal(result, unsharp)
+
+
+def test_derive_capture_profile_auto_lighting(tmp_path) -> None:
+    config = PipelineConfig(
+        input_video=tmp_path / "dummy.mp4",
+        output_dir=tmp_path,
+        enable_motion_compensation=True,
+        lighting=LightingCondition.AUTO,
+    )
+    profile = derive_capture_profile(config, {"fps": 12.0})
+    assert profile.lighting is LightingCondition.NIGHT

--- a/tests/test_preprocessors.py
+++ b/tests/test_preprocessors.py
@@ -2,11 +2,20 @@ import cv2
 import numpy as np
 
 from nest_super_sampler.preprocessors import (
+    DayNightDetailTransfer,
     Deblurrer,
     Denoiser,
     FrameProcessingPipeline,
     GlareReducer,
     build_preprocessor,
+    MotionAwareDeblurrer,
+)
+from nest_super_sampler.capture_profiles import CaptureProfile
+from nest_super_sampler.config import LightingCondition
+from nest_super_sampler.detail_models import (
+    DaytimeDetailModel,
+    analyze_frame,
+    fit_daytime_detail_model,
 )
 
 
@@ -56,6 +65,8 @@ def test_build_preprocessor_returns_none_when_disabled() -> None:
         enable_glare=False,
         enable_denoise=False,
         enable_deblur=False,
+        enable_motion_compensation=False,
+        enable_daytime_detail_transfer=False,
         glare_v_thresh=0.9,
         glare_s_thresh=0.4,
         glare_knee_tau=0.75,
@@ -76,6 +87,8 @@ def test_build_preprocessor_returns_pipeline_when_enabled() -> None:
         enable_glare=True,
         enable_denoise=True,
         enable_deblur=True,
+        enable_motion_compensation=True,
+        enable_daytime_detail_transfer=False,
         glare_v_thresh=0.9,
         glare_s_thresh=0.4,
         glare_knee_tau=0.75,
@@ -87,5 +100,81 @@ def test_build_preprocessor_returns_pipeline_when_enabled() -> None:
         denoise_search=21,
         deblur_alpha=0.6,
         deblur_sigma=1.2,
+        motion_profile=CaptureProfile(fps=30.0, lighting=LightingCondition.DAYTIME),
     )
     assert isinstance(pre, FrameProcessingPipeline)
+
+
+def test_motion_aware_deblurrer_enhances_edges() -> None:
+    profile = CaptureProfile(fps=15.0, lighting=LightingCondition.DAYTIME)
+    processor = MotionAwareDeblurrer(profile)
+    frame = np.full((20, 20, 3), 127, dtype=np.uint8)
+    cv2.line(frame, (0, 10), (19, 10), (127, 127, 127), 3)
+    blurred = cv2.GaussianBlur(frame, (0, 0), 2.5)
+    restored = processor.process(blurred)
+    assert restored.dtype == np.uint8
+    assert restored.var() >= blurred.var()
+
+
+def test_daytime_detail_model_roundtrip(tmp_path) -> None:
+    frame = np.zeros((32, 32, 3), dtype=np.uint8)
+    cv2.rectangle(frame, (4, 4), (28, 28), (255, 255, 255), 2)
+    model = fit_daytime_detail_model([frame])
+    path = tmp_path / "model.npz"
+    model.save(path)
+    loaded = DaytimeDetailModel.load(path)
+    assert loaded == model
+
+
+def test_daynight_detail_transfer_increases_gradient() -> None:
+    reference = np.zeros((32, 32, 3), dtype=np.uint8)
+    cv2.rectangle(reference, (6, 6), (26, 26), (255, 255, 255), 2)
+    cv2.line(reference, (0, 16), (31, 16), (255, 255, 255), 1)
+    model = fit_daytime_detail_model([reference])
+    transfer = DayNightDetailTransfer(model)
+    night_frame = cv2.GaussianBlur(reference, (0, 0), 2.2)
+    restored = transfer.process(night_frame)
+    blurred_gradient, _ = analyze_frame(night_frame)
+    restored_gradient, _ = analyze_frame(restored)
+    assert restored_gradient > blurred_gradient
+
+
+def test_daynight_detail_transfer_returns_unsharp_when_residual_disabled() -> None:
+    reference = np.zeros((32, 32, 3), dtype=np.uint8)
+    cv2.rectangle(reference, (6, 6), (26, 26), (255, 255, 255), 2)
+    model = fit_daytime_detail_model([reference])
+    transfer = DayNightDetailTransfer(model, residual_blend=0.0)
+    night_frame = cv2.GaussianBlur(reference, (0, 0), 1.8)
+    restored = transfer.process(night_frame)
+    gradient, laplacian = analyze_frame(night_frame)
+    alpha, sigma = model.estimate_parameters(gradient, laplacian)
+    softened = cv2.GaussianBlur(night_frame, (0, 0), sigma)
+    expected = cv2.addWeighted(night_frame, 1 + alpha, softened, -alpha, 0)
+    np.testing.assert_array_equal(restored, expected)
+
+
+def test_daynight_detail_transfer_falls_back_when_gradient_worsens(monkeypatch) -> None:
+    reference = np.zeros((32, 32, 3), dtype=np.uint8)
+    cv2.rectangle(reference, (6, 6), (26, 26), (255, 255, 255), 2)
+    model = fit_daytime_detail_model([reference])
+    transfer = DayNightDetailTransfer(model, residual_blend=0.8)
+    night_frame = cv2.GaussianBlur(reference, (0, 0), 1.4)
+
+    gradient_sequence = iter(
+        [
+            (1.0, 1.0),  # original frame metrics
+            (1.0, 1.0),  # unsharp baseline metrics
+            (0.5, 1.0),  # enhanced frame metrics cause fallback
+        ]
+    )
+
+    def fake_analyze(_: np.ndarray) -> tuple[float, float]:
+        return next(gradient_sequence)
+
+    monkeypatch.setattr("nest_super_sampler.preprocessors.analyze_frame", fake_analyze)
+
+    restored = transfer.process(night_frame)
+    alpha, sigma = model.estimate_parameters(1.0, 1.0)
+    softened = cv2.GaussianBlur(night_frame, (0, 0), sigma)
+    expected = cv2.addWeighted(night_frame, 1 + alpha, softened, -alpha, 0)
+    np.testing.assert_array_equal(restored, expected)


### PR DESCRIPTION
## Summary
- avoid unnecessary color conversions when the daytime detail transfer falls back to the unsharp baseline
- add regression tests that cover both residual-disabled and gradient-regression fallbacks for the daytime detail transfer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e11d1d440c832ca474a8d4dfac3aad