### PR TITLE
Enhance motion compensation with daytime-aware deblurring

### DIFF
--- a/nest_super_sampler/capture_profiles.py
+++ b/nest_super_sampler/capture_profiles.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict
 
+import numpy as np
+
 from .config import LightingCondition, PipelineConfig
 
 
@@ -14,6 +16,7 @@ class CaptureProfile:
 
     fps: float
     lighting: LightingCondition
+    has_daytime_reference: bool = False
 
     def motion_blur_strength(self) -> float:
         """Return a normalized blur strength estimate in the range [0.5, 3.5]."""
@@ -27,11 +30,48 @@ class CaptureProfile:
         strength = fps_term * lighting_term
         return max(0.5, min(strength, 3.5))
 
+    def exposure_time_ms(self) -> float:
+        """Estimate the effective shutter time in milliseconds."""
+
+        base = 1000.0 / max(self.fps, 0.5)
+        lighting_multiplier = 1.0 if self.lighting is LightingCondition.DAYTIME else 1.6
+        return float(min(1000.0, base * lighting_multiplier))
+
+    def motion_kernel_length(self, pixel_velocity_px: float = 12.0) -> int:
+        """Return an odd kernel length approximating the motion blur extent."""
+
+        blur_extent_px = pixel_velocity_px * (self.exposure_time_ms() / 1000.0)
+        length = int(round(max(3.0, blur_extent_px)))
+        if length % 2 == 0:
+            length += 1
+        return length
+
+    def motion_kernel(self, pixel_velocity_px: float = 12.0) -> np.ndarray:
+        """Return a 2D horizontal motion blur kernel informed by FPS and lighting."""
+
+        length = self.motion_kernel_length(pixel_velocity_px)
+        kernel = np.zeros((length, length), dtype=np.float32)
+        kernel[length // 2, :] = 1.0 / length
+        return kernel
+
+    def wiener_balance(self) -> float:
+        """Return a noise balance parameter for Wiener deconvolution."""
+
+        base = 0.0025 + 0.0015 * self.motion_blur_strength()
+        if self.lighting is LightingCondition.NIGHT:
+            base *= 1.45
+        if self.has_daytime_reference:
+            base *= 0.75
+        return float(base)
+
     def detail_gain(self) -> float:
         """Return a multiplier used to recover edge details."""
 
         base_gain = 0.8
-        return min(1.6, base_gain + 0.25 * self.motion_blur_strength())
+        gain = base_gain + 0.25 * self.motion_blur_strength()
+        if self.has_daytime_reference:
+            gain += 0.15
+        return min(1.6, gain)
 
 
 def derive_capture_profile(cfg: PipelineConfig, info: Dict[str, float]) -> CaptureProfile:
@@ -42,4 +82,8 @@ def derive_capture_profile(cfg: PipelineConfig, info: Dict[str, float]) -> Captu
         lighting = LightingCondition.DAYTIME if fps >= 20.0 else LightingCondition.NIGHT
     else:
         lighting = cfg.lighting
-    return CaptureProfile(fps=fps, lighting=lighting)
+    return CaptureProfile(
+        fps=fps,
+        lighting=lighting,
+        has_daytime_reference=cfg.enable_daytime_detail_transfer,
+    )


### PR DESCRIPTION
## Summary
- extend capture profiles with exposure-derived motion blur kernel and Wiener balance helpers
- upgrade the motion-aware deblurrer to run frequency-domain deconvolution and optionally apply daytime priors
- document the enhanced CLI/API workflow and add regression tests for the new motion-compensation logic

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'numpy' / 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68e6a5790238832c957e487b962a40a8